### PR TITLE
Improved to be able to specify the version of the aws-ssm-agent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ url: amd64
 disable_gpg_check: false
 gpg_key_url: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2bc7c7c267bbd505eaa491e6dd81a61756baa549
 gpg_key_fingerprint: 2bc7 c7c2 67bb d505 eaa4  91e6 dd81 a617 56ba a549
+aws_ssm_agent_version: latest
 ```
 
 For installation in [Raspbian](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-manual-agent-install.html#agent-install-raspbianjessie), please find the activation code and id before using this role
@@ -49,6 +50,7 @@ Amazon only keeps a signing key for a year or two. When this role is outdated an
          - role: deekayen.aws-ssm
            vars:
               gpg_key_url: https://keys.openpgp.org/vks/v1/by-fingerprint/2BC7C7C267BBD505EAA491E6DD81A61756BAA549
+              aws_ssm_agent_version: 3.0.1390.0
               aws_ssm_activation_code: activationcode_here
               aws_ssm_activation_id: myactivation_id
               aws_ssm_ec2_region: us-east-1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ url: amd64
 disable_gpg_check: false
 gpg_key_url: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2bc7c7c267bbd505eaa491e6dd81a61756baa549
 gpg_key_fingerprint: 2bc7c7c267bbd505eaa491e6dd81a61756baa549
+aws_ssm_agent_version: latest
 # aws_ssm_activation_code:
 # aws_ssm_activation_id:
 # aws_ssm_ec2_region: "{{ ec2_region }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: Install RPM file for Redhat family.
   ansible.builtin.yum:
-    name: "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_{{ url }}/amazon-ssm-agent.rpm"
+    name: "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/{{ aws_ssm_agent_version }}/linux_{{ url }}/amazon-ssm-agent.rpm"
     disable_gpg_check: "{{ disable_gpg_check }}"
     state: present
   tags:
@@ -45,7 +45,7 @@
 
 - name: Install deb file for Debian family.
   ansible.builtin.apt:
-    deb: "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_{{ url }}/amazon-ssm-agent.deb"
+    deb: "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/{{ aws_ssm_agent_version }}/debian_{{ url }}/amazon-ssm-agent.deb"
   notify: restart amazon-ssm-agent
   tags:
     - install_ssm_agent


### PR DESCRIPTION
Improved to be able to specify the version of the AWS ssm-agent.
I think this improvement is effective for version-constrained patterns such as centos6.

ex.)
https://docs.aws.amazon.com/ja_jp/systems-manager/latest/userguide/agent-install-centos.html